### PR TITLE
Correction of an UnboundLocalError in method csv_clipboard

### DIFF
--- a/health/windows10StateMachine.py
+++ b/health/windows10StateMachine.py
@@ -55,6 +55,9 @@ class Windows10StateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows10StateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows10StateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windows2003ServerR2StateMachine.py
+++ b/health/windows2003ServerR2StateMachine.py
@@ -96,6 +96,9 @@ class Windows2003ServerR2StateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows2003ServerR2StateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows2003ServerR2StateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windows2003ServerStateMachine.py
+++ b/health/windows2003ServerStateMachine.py
@@ -96,6 +96,9 @@ class Windows2003ServerStateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows2003ServerStateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows2003ServerStateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windows2008ServerR2StateMachine.py
+++ b/health/windows2008ServerR2StateMachine.py
@@ -55,6 +55,9 @@ class Windows2008ServerR2StateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows2008ServerR2StateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows2008ServerR2StateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windows2008ServerStateMachine.py
+++ b/health/windows2008ServerStateMachine.py
@@ -55,6 +55,9 @@ class Windows2008ServerStateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows2008ServerStateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows2008ServerStateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windows2012ServerR2StateMachine.py
+++ b/health/windows2012ServerR2StateMachine.py
@@ -55,6 +55,9 @@ class Windows2012ServerR2StateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows2012ServerR2StateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows2012ServerR2StateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windows2012ServerStateMachine.py
+++ b/health/windows2012ServerStateMachine.py
@@ -55,6 +55,9 @@ class Windows2012ServerStateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows2012ServerStateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows2012ServerStateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windows7StateMachine.py
+++ b/health/windows7StateMachine.py
@@ -55,6 +55,9 @@ class Windows7StateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows7StateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows7StateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windows8StateMachine.py
+++ b/health/windows8StateMachine.py
@@ -55,6 +55,9 @@ class Windows8StateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows8StateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows8StateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windows8_1StateMachine.py
+++ b/health/windows8_1StateMachine.py
@@ -55,6 +55,9 @@ class Windows8_1StateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(Windows8_1StateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(Windows8_1StateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windowsVistaStateMachine.py
+++ b/health/windowsVistaStateMachine.py
@@ -52,6 +52,9 @@ class WindowsVistaStateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(WindowsVistaStateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(WindowsVistaStateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/health/windowsXPStateMachine.py
+++ b/health/windowsXPStateMachine.py
@@ -96,6 +96,9 @@ class WindowsXPStateMachine(_Statemachine):
     def csv_list_running_proccess(self):
         super(WindowsXPStateMachine, self)._csv_list_running_process(self._list_running())
 
+    def csv_hash_running_proccess(self):
+        super(Windows10StateMachine, self)._csv_hash_running_process(self._list_running())
+
     def csv_list_sessions(self):
         super(WindowsXPStateMachine, self)._csv_list_sessions(self._list_sessions())
 

--- a/memory/mem.py
+++ b/memory/mem.py
@@ -226,13 +226,16 @@ class _Memory(object):
         with open(self.output_dir + '\\' + self.computer_name + '_clipboard.csv', 'wb') as output:
             csv_writer = get_csv_writer(output)
             write_to_csv(["COMPUTER_NAME", "TYPE", "DATA"], csv_writer)
+
+            r = None    #initialize the local variable r
             try:
                 r = Tk()  # Using Tk instead because it supports exotic characters
                 data = r.selection_get(selection='CLIPBOARD')
                 r.destroy()
                 write_to_csv([self.computer_name, 'clipboard', unicode(data)], csv_writer)
             except:
-                r.destroy()
+                if r != None:   # Verify that r exist before calling destroy
+                    r.destroy()
                 win32clipboard.OpenClipboard()
                 clip = win32clipboard.EnumClipboardFormats(0)
                 while clip:

--- a/registry/reg.py
+++ b/registry/reg.py
@@ -63,7 +63,7 @@ def csv_user_assist_value_decode_win7_and_after(str_value_datatmp, count_offset)
     str_value_data_focus = unicode(struct.unpack("<I", str_value_data_focus)[0])
     str_value_data_timestamp = str_value_datatmp[60:68]
     try:
-        timestamp = struct.unpack("<I", str_value_data_timestamp)[0]
+        timestamp = struct.unpack("<Q", str_value_data_timestamp)[0]
         date_last_exec = convert_windate(timestamp)
     except ValueError:
         date_last_exec = None
@@ -93,7 +93,7 @@ def csv_user_assist_value_decode_before_win7(str_value_datatmp, count_offset):
     str_value_data_count = unicode(struct.unpack("<I", str_value_data_count)[0] + count_offset + 1)
     str_value_data_timestamp = str_value_datatmp[8:16]
     try:
-        timestamp = struct.unpack("<I", str_value_data_timestamp)[0]
+        timestamp = struct.unpack("<Q", str_value_data_timestamp)[0]
         date_last_exec = convert_windate(timestamp)
     except ValueError:
         date_last_exec = None

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -431,6 +431,16 @@ def record_sha256_logs(fr, fw):
         hash_file.close()
 
 
+def process_md5(path):
+    with open(path, "rb") as f:
+        return hashlib.md5(f.read()).hexdigest()
+
+
+def process_sha1(path):
+    with open(path, "rb") as f:
+        return hashlib.sha1(f.read()).hexdigest()
+
+
 def process_sha256(path):
     with open(path, "rb") as f:
         return hashlib.sha256(f.read()).hexdigest()


### PR DESCRIPTION
In method csv_clipboard, initialisation of the local variable 'r' to
avoid calling the method destroy on a non initialized local variable.